### PR TITLE
Really tiny typo fix

### DIFF
--- a/docs/basic-usage/standalone-php.md
+++ b/docs/basic-usage/standalone-php.md
@@ -1,6 +1,6 @@
 # Standalone PHP
 
-Optimizing and compressing PDF files in your PHP applications is a breeze with the PhpOptimizer class. This class provides a simple and effective way to enhance the performance of your PDFs while minimizing file sizes.
+Optimizing and compressing PDF files in your PHP applications is a breeze with the PdfOptimizer class. This class provides a simple and effective way to enhance the performance of your PDFs while minimizing file sizes.
 
 
 


### PR DESCRIPTION
Hi! First, thanks for this. It really saved my bacon on something I was working on with clients uploading enormous PDFs that they just wouldn't optimise themselves so I had to automate it as part of the upload process. Thank you for that. 

Second, as a very modest way of giving back I'd like to highlight a (really tiny) typo I noticed in the docs for the standalone PHP implementation. 

I've just changed:

> `PhpOptimizer`

... to:

> `PdfOptimizer`

... because the latter is what it's actually called! :)