### PR TITLE
Allow Symfony 8 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^8.2",
         "ext-fileinfo": "*",
         "psr/log": "^3.0",
-        "symfony/process": "^6.2|^7.0"
+        "symfony/process": "^6.2|^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^v8.19.0|^9.0|^10.0",


### PR DESCRIPTION
Symfony 8 has been released recently.

But the bundle doesn't allow to use it. 