### PR TITLE
Flag attributes & Devices Enum

### DIFF
--- a/src/Attributes/Flag.php
+++ b/src/Attributes/Flag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mostafaznv\PdfOptimizer\Attributes;
+
+use Attribute;
+
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Flag
+{
+    public function __construct(public string $name) {}
+}

--- a/src/Concerns/ExportsScript.php
+++ b/src/Concerns/ExportsScript.php
@@ -3,6 +3,7 @@
 namespace Mostafaznv\PdfOptimizer\Concerns;
 
 use BackedEnum;
+use Mostafaznv\PdfOptimizer\Attributes\Flag;
 use Mostafaznv\PdfOptimizer\Attributes\Option;
 use ReflectionClass;
 
@@ -11,11 +12,10 @@ trait ExportsScript
 {
     public function command(?string $pathToFile = null, ?string $pathToOptimizedFile = null): array
     {
-        $options = $this->options;
+        $options = [];
         $reflection = new ReflectionClass($this);
 
         foreach ($reflection->getProperties() as $property) {
-            $attributes = $property->getAttributes(Option::class);
             $value = $property->getValue($this);
 
             if (is_null($value)) {
@@ -24,6 +24,15 @@ trait ExportsScript
 
             $value = is_a($value, BackedEnum::class) ? $value->value : $value;
 
+            $attributes = $property->getAttributes(Flag::class);
+            foreach ($attributes as $attribute) {
+                if ($value == true) {
+                    $instance = $attribute->newInstance();
+                    $options[] = $instance->name;
+                }
+            }
+
+            $attributes = $property->getAttributes(Option::class);
             foreach ($attributes as $attribute) {
                 $instance = $attribute->newInstance();
 

--- a/src/Concerns/PdfOptimizerProperties.php
+++ b/src/Concerns/PdfOptimizerProperties.php
@@ -2,6 +2,7 @@
 
 namespace Mostafaznv\PdfOptimizer\Concerns;
 
+use Mostafaznv\PdfOptimizer\Attributes\Flag;
 use Mostafaznv\PdfOptimizer\Attributes\Option;
 use Mostafaznv\PdfOptimizer\Enums\AutoRotatePages;
 use Mostafaznv\PdfOptimizer\Enums\ColorConversionStrategy;
@@ -10,6 +11,7 @@ use Mostafaznv\PdfOptimizer\Enums\ColorImageDownSampleType;
 use Mostafaznv\PdfOptimizer\Enums\ImageFilter;
 use Mostafaznv\PdfOptimizer\Enums\CompatibilityLevel;
 use Mostafaznv\PdfOptimizer\Enums\DefaultRenderingIntent;
+use Mostafaznv\PdfOptimizer\Enums\Device;
 use Mostafaznv\PdfOptimizer\Enums\GrayImageDownSampleType;
 use Mostafaznv\PdfOptimizer\Enums\MonoImageDownSampleType;
 use Mostafaznv\PdfOptimizer\Enums\MonoImageFilter;
@@ -24,15 +26,19 @@ trait PdfOptimizerProperties
     /**
      * @var string[]
      */
-    private array $options = [
-        '-sDEVICE=pdfwrite', '-dNOPAUSE', '-dQUIET', '-dBATCH'
-    ];
-
-    /**
-     * @var string[]
-     */
     private array $extraOptions = [];
 
+    #[Option('-sDEVICE')]
+    protected Device $device = Device::PDFWRITE;
+
+    #[Flag('-dNOPAUSE')]
+    protected bool $nopause = true;
+
+    #[Flag('-dQUIET')]
+    protected bool $quiet = true;
+
+    #[Flag('-dBATCH')]
+    protected bool $batch = true;
 
     #[Option('-dPDFSETTINGS')]
     private PdfSettings $pdfSettings = PdfSettings::SCREEN;
@@ -197,6 +203,21 @@ trait PdfOptimizerProperties
     private ?DefaultRenderingIntent $defaultRenderingIntent = null;
 
     private int $timeout = 300;
+
+    /**
+     * #### Quiet
+     *
+     * Suppresses routine information comments on standard output. This is currently necessary when redirecting device output to standard output.
+     *
+     * @param bool $quiet
+     * @return PdfOptimizerProperties|PdfOptimizer
+     */
+    public function quiet(bool $quiet): self
+    {
+        $this->quiet = $quiet;
+
+        return $this;
+    }
 
 
     /**
@@ -1142,6 +1163,23 @@ trait PdfOptimizerProperties
     public function processColorModel(ProcessColorModel $model): self
     {
         $this->processColorModel = $model;
+
+        return $this;
+    }
+
+    /**
+     * #### device
+     *
+     * Selects an alternate initial output device.
+     *
+     * Ghostscript has a notion of ‘output devices’ which handle saving or displaying the results in a particular format. Ghostscript comes with a diverse variety of such devices supporting vector and raster file output, screen display, driving various printers and communicating with other applications.
+     *
+     * @param Device $device
+     * @return PdfOptimizerProperties|PdfOptimizer
+     */
+    public function device(Device $device): self
+    {
+        $this->device = $device;
 
         return $this;
     }

--- a/src/Enums/Device.php
+++ b/src/Enums/Device.php
@@ -10,11 +10,11 @@ enum Device: string
      */
 
     /** EPS output (like PostScript Distillery) */
-    case EPSWRITE = 'epswrite';
+    case EPSWRITE = 'eps2write';
     /** PDF output (like Adobe Acrobat Distiller) */
     case PDFWRITE = 'pdfwrite';
     /** PostScript output (like PostScript Distillery) */
-    case PSWRITE = 'pswrite';
+    case PSWRITE = 'ps2write';
     /** Black-and-white PCL XL */
     case PXLMONO = 'pxlmono';
     /** Color PCL XL */

--- a/src/Enums/Device.php
+++ b/src/Enums/Device.php
@@ -14,9 +14,9 @@ enum Device: string
     /** PDF output (like Adobe Acrobat Distiller) */
     case PDFWRITE = 'pdfwrite';
     /** PostScript output (like PostScript Distillery) */
-    case PSWRITE = 'pswrite' ;
+    case PSWRITE = 'pswrite';
     /** Black-and-white PCL XL */
-    case PXLMONO = 'pxlmono' ;
+    case PXLMONO = 'pxlmono';
     /** Color PCL XL */
     case PXLCOLOR = 'pxlcolor';
 

--- a/src/Enums/Device.php
+++ b/src/Enums/Device.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Mostafaznv\PdfOptimizer\Enums;
+
+
+enum Device: string
+{
+    /**
+     * High-level (vector) file formats
+     */
+
+    /** EPS output (like PostScript Distillery) */
+    case EPSWRITE = 'epswrite';
+    /** PDF output (like Adobe Acrobat Distiller) */
+    case PDFWRITE = 'pdfwrite';
+    /** PostScript output (like PostScript Distillery) */
+    case PSWRITE = 'pswrite' ;
+    /** Black-and-white PCL XL */
+    case PXLMONO = 'pxlmono' ;
+    /** Color PCL XL */
+    case PXLCOLOR = 'pxlcolor';
+
+    /**
+     * Other raster file formats and devices
+     */
+
+    /** Plain bits, monochrome */
+    case BIT = 'bit';
+    /** Plain bits, RGB */
+    case BITRGB = 'bitrgb';
+    /** Plain bits, CMYK */
+    case BITCMYK = 'bitcmyk';
+    /** Monochrome MS Windows .BMP file format */
+    case BMPMONO = 'bmpmono';
+    /** 8-bit gray .BMP file format */
+    case BMPGRAY = 'bmpgray';
+    /** Separated 1-bit CMYK .BMP file format, primarily for testing */
+    case BMPSEP1 = 'bmpsep1';
+    /** Separated 8-bit CMYK .BMP file format, primarily for testing */
+    case BMPSEP8 = 'bmpsep8';
+    /** 4-bit (EGA/VGA) .BMP file format */
+    case BMP4 = 'bmp16';
+    /** 8-bit (256-color) .BMP file format */
+    case BMP8 = 'bmp256';
+    /** 24-bit .BMP file format */
+    case BMP24 = 'bmp16m';
+    /** 32-bit pseudo-.BMP file format */
+    case BMP32 = 'bmp32b';
+    /** Monochrome (black-and-white) CGM -- LOW LEVEL OUTPUT ONLY */
+    case CGMMONO = 'cgmmono';
+    /** 8-bit (256-color) CGM -- DITTO */
+    case CGM8 = 'cgm8';
+    /** 24-bit color CGM -- DITTO */
+    case CGM24 = 'cgm24';
+    /** JPEG format, RGB output */
+    case JPEG = 'jpeg';
+    /** JPEG format, gray output */
+    case JPEGGRAY = 'jpeggray';
+    /** ImageMagick MIFF format, 24-bit direct color, RLE compressed */
+    case MIFF = 'miff24';
+    /** PCX file format, monochrome (1-bit black and white) */
+    case PCXMONO = 'pcxmono';
+    /** PCX file format, 8-bit gray scale */
+    case PCXGRAY = 'pcxgray';
+    /** PCX file format, 4-bit planar (EGA/VGA) color */
+    case PCX4 = 'pcx16';
+    /** PCX file format, 8-bit chunky color */
+    case PCX8 = 'pcx256';
+    /** PCX file format, 24-bit color (3 8-bit planes) */
+    case PCX24 = 'pcx24b';
+    /** PCX file format, 4-bit chunky CMYK color */
+    case PCXCMYK = 'pcxcmyk';
+    /** Portable Bitmap (plain format) */
+    case PBM = 'pbm';
+    /** Portable Bitmap (raw format) */
+    case PBMRAW = 'pbmraw';
+    /** Portable Graymap (plain format) */
+    case PGM = 'pgm';
+    /** Portable Graymap (raw format) */
+    case PGMRAW = 'pgmraw';
+    /** Portable Graymap (plain format), optimizing to PBM if possible */
+    case PGNM = 'pgnm';
+    /** Portable Graymap (raw format), optimizing to PBM if possible */
+    case PGNMRAW = 'pgnmraw';
+    /** Portable Pixmap (plain format) (RGB), optimizing to PGM or PBM if possible */
+    case PNM = 'pnm';
+    /** Portable Pixmap (raw format) (RGB), optimizing to PGM or PBM if possible */
+    case PNMRAW = 'pnmraw';
+    /** Portable Pixmap (plain format) (RGB) */
+    case PPM = 'ppm';
+    /** Portable Pixmap (raw format) (RGB) */
+    case PPMRAW = 'ppmraw';
+    /** Portable inKmap (plain format) (4-bit CMYK => RGB) */
+    case PKM = 'pkm';
+    /** Portable inKmap (raw format) (4-bit CMYK => RGB) */
+    case PKMRAW = 'pkmraw';
+    /** Portable Separated map (plain format) (4-bit CMYK => 4 pages) */
+    case PKSM = 'pksm';
+    /** Portable Separated map (raw format) (4-bit CMYK => 4 pages) */
+    case PKSMRAW = 'pksmraw';
+    /** Plan 9 bitmap format */
+    case PLAN9BM = 'plan9bm';
+    /** Monochrome Portable Network Graphics (PNG) */
+    case PNGMONO = 'pngmono';
+    /** 8-bit gray Portable Network Graphics (PNG) */
+    case PNGGRAY = 'pnggray';
+    /** 4-bit color Portable Network Graphics (PNG) */
+    case PNG4 = 'png16';
+    /** 8-bit color Portable Network Graphics (PNG) */
+    case PNG8 = 'png256';
+    /** 24-bit color Portable Network Graphics (PNG) */
+    case PNG24 = 'png16m';
+    /** PostScript (Level 1) monochrome image */
+    case PSMONO = 'psmono';
+    /** PostScript (Level 1) 8-bit gray image */
+    case PSGRAY = 'psgray';
+    /** PostScript (Level 2) 24-bit color image */
+    case PSRGB = 'psrgb';
+    /** TIFF 12-bit RGB, no compression */
+    case TIFF12 = 'tiff12nc';
+    /** TIFF 24-bit RGB, no compression (NeXT standard format) */
+    case TIFF24 = 'tiff24nc';
+    /** TIFF LZW (tag = 5) (monochrome) */
+    case TIFFLZW = 'tifflzw';
+    /** TIFF PackBits (tag = 32773) (monochrome) */
+    case TIFFPACK = 'tiffpack';
+}


### PR DESCRIPTION
Create Flag attributes:
- Switches like -dQUIET can be defined and set just like other properties.
- An array with the default options is no longer necessary.

Create Device enum:
- The enum Device allows you to easily set High-level (vector) and raster file formats.
- https://www.gnu.org/software/ghostscript/devices.html